### PR TITLE
Close button label text and optional clear button

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-hacker

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-hacker

--- a/lib/searchable_dropdown.dart
+++ b/lib/searchable_dropdown.dart
@@ -271,12 +271,11 @@ class DropdownDialog<T> extends StatefulWidget {
   }) :  assert(items != null),
         super(key: key);
 
-  _DropdownDialogState createState() => new _DropdownDialogState(closeButtonText);
+  _DropdownDialogState createState() => new _DropdownDialogState();
 }
 
 class _DropdownDialogState extends State<DropdownDialog> {
 
-  final String closeButtonText;
   TextEditingController txtSearch = new TextEditingController();
   TextStyle defaultButtonStyle = new TextStyle(
       fontSize: 16,
@@ -284,7 +283,7 @@ class _DropdownDialogState extends State<DropdownDialog> {
   );
   List<int> shownIndexes = [];
 
-  _DropdownDialogState(this.closeButtonText);
+  _DropdownDialogState();
 
   void _updateShownIndexes(String keyword){
     shownIndexes.clear();
@@ -440,7 +439,7 @@ class _DropdownDialogState extends State<DropdownDialog> {
               Navigator.pop(context);
             },
             child: new Text(
-                closeButtonText,
+                widget.closeButtonText,
                 style: defaultButtonStyle
             ),
           )


### PR DESCRIPTION
Hello @icemanbsi ,

Thanks for `searchable_dropdown`!

This pull request proposes 2 things:
- Close button label text: optionally change the "Close" text of the search dialog for example to allow translation.
- Clear button: optionally add a clear button [X] on the right of the dropdown as requested by @Laban1 here: https://github.com/icemanbsi/searchable_dropdown/issues/5

For the clear button:
- By default, it is not displayed
- It is active if and only if a value is selected
- The default icon [X] can be given as a parameter
- A callback function (onClear) can be given as a parameter and is called when the user clicks on the clear button