### PR TITLE
zebra regression, avoid assert, selected widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Searchable dropdown item inside a dialog
 | displayClearButton      | bool            | false                                                                                                             |
 | clearIcon               | Widget          | Icon(Icons.clear)                                                                                                 |
 | onClear                 | Function        | null                                                                                                             |
+| selectedValueWidgetFn   | Function        | null                                                                                                             |
+| assertUniqueValue       | bool            | true                                                                                                             |
 
 
 ## Usage
@@ -65,4 +67,15 @@ Widget widget() {
      },
    );
 }
+```
+
+It can be that one wants to display the selected value differently than in the list. In this case, the parameter selectedValueWidgetFn can be used to customize the rendering widget. Here is an example with an outcome similar to the one in the main.dart example:
+```
+selectedValueWidgetFn: (value) => Padding(
+  padding: EdgeInsets.fromLTRB(20, 20, 20, 20),
+  child:Text(
+    value??"Select please",
+    style: value==null?TextStyle(color:Theme.of(context).hintColor):null,
+  )
+),
 ```


### PR DESCRIPTION
Hello @icemanbsi ,

Proposing those 4 changes:

1. Solve zebra regression on issue #4 due to clear button PR #8

While introducing the clear button, PR #8 introduced a regression on issue #4 . The result was some zebras with the example given in the issue. Sorry about that. The solution consisted in adding another conditional Expanded.

2. Allow avoid assert unique value issue #6

Issue #6 describes a situation where values are not consistent and lead to error messages due to an assert in _updateSelectedIndex . The new assertUniqueValue parameter set to true by default lets the caller decide whether or not to perform this assert. This can temporarily prevent code modification while testing the plugin with inconsistent data.

3. Custom selected item widget function

It can be that one wants to display the selected value differently than in the list. In this case, the new parameter selectedValueWidgetFn can be used to customize the rendering widget. Here is an example with an outcome similar to the one in the main.dart example:
selectedValueWidgetFn: (value) => Padding(
  padding: EdgeInsets.fromLTRB(20, 20, 20, 20),
  child:Text(
    value??"Select please",
    style: value==null?TextStyle(color:Theme.of(context).hintColor):null,
  )
),

4. Warning

Got rid of a warning: IconColor getters end with a return to take into account situations not covered by the case.