### PR TITLE
Fixes #24

### DIFF
--- a/lib/searchable_dropdown.dart
+++ b/lib/searchable_dropdown.dart
@@ -447,12 +447,14 @@ class _SearchableDropdownState<T> extends State<SearchableDropdown<T>> {
       }
     }
     if (selectedItems == null) selectedItems = [];
+    selectedItems.removeWhere((item) => item >= widget.items.length);
     super.initState();
   }
 
   @override
   void didUpdateWidget(SearchableDropdown oldWidget) {
     super.didUpdateWidget(oldWidget);
+    selectedItems?.removeWhere((item) => item >= widget.items.length);
   }
 
   Widget get menuWidget {


### PR DESCRIPTION
When widget is created or updated, there should be a check whether `selectedItems` now points to an invalid item (e.g. removed)