### PR TITLE
Flutter 2.5 compatibility

### DIFF
--- a/lib/searchable_dropdown.dart
+++ b/lib/searchable_dropdown.dart
@@ -373,10 +373,10 @@ class _SearchableDropdownState<T> extends State<SearchableDropdown<T>> {
   TextStyle get _textStyle =>
       widget.style ??
       (_enabled && !(widget.readOnly ?? false)
-          ? Theme.of(context).textTheme.subhead
+          ? Theme.of(context).textTheme.subtitle1 /** dosen't working in flutter 2.5 replace subhead **/
           : Theme.of(context)
               .textTheme
-              .subhead
+              .subtitle1 /** dosen't working in flutter 2.5 replace subhead **/
               .copyWith(color: _disabledIconColor));
   bool get _enabled =>
       widget.items != null &&


### PR DESCRIPTION
fix /usr/local/Caskroom/flutter/2.0.2/flutter/.pub-cache/hosted/pub.dartlang.org/searchable_dropdown-1.1.3/lib/searchable_dropdown.dart:371:41: Error: The getter 'subhead' isn't defined for the class 'TextTheme'.
     - 'TextTheme' is from 'package:flutter/src/material/text_theme.dart' ('/usr/local/Caskroom/flutter/2.0.2/flutter/packages/flutter/lib/src/material/text_theme.dart').
    Try correcting the name to the name of an existing getter, or defining a getter or field named 'subhead'.
              ? Theme.of(context).textTheme.subhead